### PR TITLE
fixed ndWeekly returning dat equal to d instead of the next dat

### DIFF
--- a/calculator.go
+++ b/calculator.go
@@ -121,7 +121,7 @@ outerLoop:
 				continue
 			}
 			dat = dat.Add(timeOfDay)
-			if dat.Before(d) {
+			if !dat.After(d) {
 				continue
 			}
 			if end.After(start) && dat.After(end) {

--- a/weekly_test.go
+++ b/weekly_test.go
@@ -65,7 +65,7 @@ func TestWeeklyPattern(t *testing.T) {
 					So(nextEvent, ShouldHappenOn, time.Date(2016, 1, 2, 12, 0, 0, 0, local))
 				})
 				Convey("the second event 11th january", func() {
-					nextEvent := r.GetNextDate(time.Date(2016, 1, 2, 13, 0, 0, 0, time.UTC))
+					nextEvent := r.GetNextDate(time.Date(2016, 1, 2, 12, 0, 0, 0, time.UTC))
 					So(nextEvent, ShouldHappenOn, time.Date(2016, 1, 11, 12, 0, 0, 0, local))
 				})
 				Convey("there should be another event on 12th feburary", func() {


### PR DESCRIPTION
Passing a date into ndWeekly that matches the criteria was returning that date instead of the next date.

Issue seems to be with ndWeekly checking:
```
if dat.Before(d) {
    continue
}
```
instead of:
```
if !dat.After(d) {
    continue
}
```

Updated ndWeekly and tweaked weekly_test.go to cover this issue.